### PR TITLE
Make Puppeteer to wait until fonts render

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -9,7 +9,21 @@ const loadFont = file => {
   return font.toString("base64")
 }
 
-const generateHTML = (title = "Hello world") => {
+const injectFile = async (page, filePath) => {
+
+  let contents = await new Promise((resolve, reject) => {
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) return reject(err)
+      resolve(data)
+    })
+  })
+
+  contents += `//# sourceURL=` + filePath.replace(/\n/g,'')
+
+  return page.mainFrame().evaluate(contents)
+}
+
+const generateHTML = (title = "Hello world", host) => {
   return `<html>
     <style>
       * {
@@ -31,17 +45,13 @@ const generateHTML = (title = "Hello world") => {
         font-family: 'Ayer Poster Angular';
         font-style: italic;
         font-weight: bold;
-        src: url('data:font/woff2;base64,${loadFont(
-          "AyerPosterAngular-SemiboldItalic-Web.woff2"
-        )}') format('woff2');
+        src: url('https://${host}/static/AyerPosterAngular-SemiboldItalic-Web.woff2');
       }
 
       @font-face {
         font-family: 'National 2';
         font-style: italic;
-        src: url('data:font/woff2;base64,${loadFont(
-          "National2Web-RegularItalic.woff2"
-        )}') format('woff2');
+        src: url('https://${host}/static/National2Web-RegularItalic.woff2');
       }
 
       .title {
@@ -83,6 +93,17 @@ const getScreenshot = async function({ html, type = "png" }) {
   if (!html) {
     throw Error("You must provide an html property.")
   }
+  
+  // The fonts to wait on before taking screenshot
+  const fontsToLoad = [
+    'Ayer Poster Angular',
+    'National 2',
+    // 'Montserrat',
+    // 'Raleway'
+  ]
+  
+  // Build JS to wait on each font unitil it's visible
+  const waitForFontFaces = `Promise.all([ '${fontsToLoad.join(`', '`)}' ].map(fontName => (new FontFaceObserver(fontName)).load()))`
 
   const browser = await puppeteer.launch({
     args: chrome.args,
@@ -93,7 +114,16 @@ const getScreenshot = async function({ html, type = "png" }) {
   const page = await browser.newPage()
   await page.setContent(html, { waitUntil: "networkidle2" })
   const element = await page.$("html")
-  await page.evaluateHandle("document.fonts.ready")
+
+  // Load Google Fonts
+  // await page.addStyleTag({url: 'https://fonts.googleapis.com/css2?family=Lato&family=Lilita+One&family=Montez&family=Montserrat+Alternates:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Montserrat+Subrayada:wght@400;700&family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&family=Orbitron:wght@400;500;600;700;800;900&family=Oswald&family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,669;0,700;0,800;0,900;1,400;1,500;1,600;1,669;1,700;1,800;1,900&family=Raleway:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700&family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap'})
+
+  // Load and run fontfaceobserver on screenshot page
+  await injectFile(page, path.join(__dirname, '../node_modules/fontfaceobserver/fontfaceobserver.standalone.js'))
+
+  // Wait for font faces to be rendered
+  await page.evaluate(waitForFontFaces)
+
   return await element.screenshot({ type }).then(async data => {
     await browser.close()
     return data
@@ -107,7 +137,7 @@ export default async (request: NowRequest, response: NowResponse) => {
     response.status(404).end()
   }
 
-  const html = generateHTML(String(title))
+  const html = generateHTML(String(title), request.headers['x-now-deployment-url'])
   const result = await getScreenshot({ html })
   response.writeHead(200, { "Content-Type": "image/png" })
   response.end(result)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@now/node": "^1.4.1",
     "@types/sharp": "^0.24.0",
     "chrome-aws-lambda": "^2.1.1",
+    "fontfaceobserver": "^2.1.0",
     "puppeteer-core": "^2.1.1",
     "sharp": "^0.25.1"
   }


### PR DESCRIPTION
This should fix the issue with puppeteer missing timing on the fonts. 

I tested it using a bunch of Google fonts and it seems to have no problem waiting for them to load. 

You can take a look at it working here: https://og-image-generator-nedioicb1.now.sh/

Source Code with Google Fonts
https://zeit.co/samcarlton/og-image-generator/nedioicb1/source?f=src%2Fapi%2Findex.ts